### PR TITLE
10位版图像缺乱补丁(Fix two corrupt-output issues in 10-bit build)

### DIFF
--- a/libuavs3e.c
+++ b/libuavs3e.c
@@ -153,6 +153,7 @@ static void __imgb_cpy_plane(void *src, void *dst, int bw, int h, int s_src, int
 
 static void uavs3e_image_copy_pic(void *dst[4], int i_dst[4], unsigned char *const src[4], const int i_src[4],  enum AVPixelFormat pix_fmts, int width, int height)
 {
+    width=(sizeof(pel)>1)?width<<1:width;
     __imgb_cpy_plane(src[0], dst[0], width,      height,      i_src[0], i_dst[0]);
 	__imgb_cpy_plane(src[1], dst[1], width >> 1, height >> 1, i_src[1], i_dst[1]);
 	__imgb_cpy_plane(src[2], dst[2], width >> 1, height >> 1, i_src[2], i_dst[2]);


### PR DESCRIPTION
修正两问题(two issues were fixed in this patch):
1. https://github.com/uavs3/uavs3e_ffmpeg_interface/issues/1
10位版编码YUV420P10LE输入时, 结果图像右半缺失.
(Before the patch,  the 10-bit build produces images without the right half when the input is in yuv420p10le format.)

2. https://github.com/uavs3/uavs3e_ffmpeg_interface/issues/4
10位版编码yuv420p输入时, 结果图像破碎.
(Before the patch,  the 10-bit build produces corrupt images when the input is in yuv420p format.)